### PR TITLE
convert_val: print raw register value as well

### DIFF
--- a/wtd.py
+++ b/wtd.py
@@ -79,7 +79,9 @@ def convert_val(val, register_data):
           if val & genmask_mask(mask["mask"]):
                out_str += mask["name"] + "=" \
                + hex(val & genmask_mask(mask["mask"]) >> mask["mask"][1]) + "|"
-     return out_str[:-1]
+     if len(out_str) == 0:
+         return out_str
+     return out_str[:-1] + "=" + hex(val)
 
 """
 Iterate through a logfile, find matches of "addr = xyz" and "val = xyz"


### PR DESCRIPTION
As the tool doesn't currently notice when a bit is set that is not
defined in the header, re(?)-add printing the raw hex value of the
register.

Useful for example here (where bit 3 doesn't have a define):
```
[    4.507546] aw8695_i2c_read: addr = AW8695_REG_ANADBG, val = AW8695_BIT_ANADBG_IOC_3P65A=0x16
[    4.512645] aw8695_i2c_write: addr = AW8695_REG_ANADBG, val = AW8695_BIT_ANADBG_IOC_3P65A=0x1e
```